### PR TITLE
Enable the libnewrelic.a to have access to the following agent attributes

### DIFF
--- a/include/libnewrelic.h
+++ b/include/libnewrelic.h
@@ -1273,14 +1273,14 @@ bool newrelic_set_transaction_uri(newrelic_txn_t* transaction,
  *
  * @return true on success
  */
-bool newrelic_set_request_referer(newrelic_txn_t * transaction,
+bool newrelic_set_request_referer(newrelic_txn_t* transaction,
                                   const char* request_referer);
 
 /**
  * @brief Set request content length
  *
- * Given an active transaction and a content length, this function sets the transaction
- * request's content length to the given content_length
+ * Given an active transaction and a content length, this function sets the
+ * transaction request's content length to the given content_length
  *
  * @param [in] transaction    An active transaction
  * @param [in] content_length Request content length
@@ -1293,16 +1293,15 @@ bool newrelic_set_request_content_length(newrelic_txn_t* transaction,
 /**
  * @brief Set http status
  *
- * Given an active transaction and a http status code, this function sets the transaction's
- * status code to the given status code
+ * Given an active transaction and a http status code, this function sets the
+ * transaction's status code to the given status code
  *
  * @param [in] transaction    An active transaction
  * @param [in] code           HTTP Status Code
  *
  * @return true on success
  */
-bool newrelic_set_http_status(newrelic_txn_t* transaction,
-                              int http_code);
+bool newrelic_set_http_status(newrelic_txn_t* transaction, int http_code);
 /**
  * A list of examples for Doxygen to cross-reference. If a function in
  * libnewrelic.h appears in one of these examples, the example source

--- a/include/libnewrelic.h
+++ b/include/libnewrelic.h
@@ -1249,6 +1249,61 @@ bool newrelic_set_transaction_name(newrelic_txn_t* transaction,
                                    const char* transaction_name);
 
 /**
+ * @brief Set transaction uri
+ *
+ * Given an active transaction and a uri, this function sets the transaction
+ * uri to the given uri
+ *
+ * @param [in] transaction An active transaction
+ * @param [in] uri         Uri for the transaction
+ *
+ * @return true on success
+ */
+bool newrelic_set_transaction_uri(newrelic_txn_t* transaction,
+                                  const char* transaction_uri);
+
+/**
+ * @brief Set request referer
+ *
+ * Given an active transaction and a referer, this function sets the transaction
+ * referer to the given request referer
+ *
+ * @param [in] transaction An active transaction
+ * @param [in] referer     Request referer
+ *
+ * @return true on success
+ */
+bool newrelic_set_request_referer(newrelic_txn_t * transaction,
+                                  const char* request_referer);
+
+/**
+ * @brief Set request content length
+ *
+ * Given an active transaction and a content length, this function sets the transaction
+ * request's content length to the given content_length
+ *
+ * @param [in] transaction    An active transaction
+ * @param [in] content_length Request content length
+ *
+ * @return true on success
+ */
+bool newrelic_set_request_content_length(newrelic_txn_t* transaction,
+                                         const char* content_length);
+
+/**
+ * @brief Set http status
+ *
+ * Given an active transaction and a http status code, this function sets the transaction's
+ * status code to the given status code
+ *
+ * @param [in] transaction    An active transaction
+ * @param [in] code           HTTP Status Code
+ *
+ * @return true on success
+ */
+bool newrelic_set_http_status(newrelic_txn_t* transaction,
+                              int http_code);
+/**
  * A list of examples for Doxygen to cross-reference. If a function in
  * libnewrelic.h appears in one of these examples, the example source
  * file appears under the "Examples" header.

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -185,26 +185,26 @@ bool newrelic_set_transaction_name(newrelic_txn_t* transaction,
 
 bool newrelic_set_transaction_uri(newrelic_txn_t* transaction,
                                   const char* uri) {
-    if (NULL == transaction) {
-      nrl_error(NRL_API, "unable to set uri on NULL transaction");
-      return false;
-    }
+  if (NULL == transaction) {
+    nrl_error(NRL_API, "unable to set uri on NULL transaction");
+    return false;
+  }
 
-    if (NULL == uri) {
-      nrl_error(NRL_API, "uri cannot be NULL");
-      return false;
-    }
+  if (NULL == uri) {
+    nrl_error(NRL_API, "uri cannot be NULL");
+    return false;
+  }
 
-    nr_txn_set_request_uri(transaction->txn, uri);
-    nrl_debug(NRL_API, "uri set to: \"%s\"", uri);
-    return true;
+  nr_txn_set_request_uri(transaction->txn, uri);
+  nrl_debug(NRL_API, "uri set to: \"%s\"", uri);
+  return true;
 }
 
 bool newrelic_set_request_referer(newrelic_txn_t* transaction,
                                   const char* request_referer) {
   if (NULL == transaction) {
-      nrl_error(NRL_API, "unable to set referer on NULL transaction");
-      return false;
+    nrl_error(NRL_API, "unable to set referer on NULL transaction");
+    return false;
   }
 
   if (NULL == request_referer) {
@@ -234,9 +234,7 @@ bool newrelic_set_request_content_length(newrelic_txn_t* transaction,
   return true;
 }
 
-bool newrelic_set_http_status(newrelic_txn_t* transaction,
-                              int http_code) {
-
+bool newrelic_set_http_status(newrelic_txn_t* transaction, int http_code) {
   if (NULL == transaction) {
     nrl_error(NRL_API, "unable to set http_code on NULL transactin");
     return false;

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -182,3 +182,72 @@ bool newrelic_set_transaction_name(newrelic_txn_t* transaction,
   nrl_error(NRL_API, "unable to name transaction");
   return false;
 }
+
+bool newrelic_set_transaction_uri(newrelic_txn_t* transaction,
+                                  const char* uri) {
+    if (NULL == transaction) {
+      nrl_error(NRL_API, "unable to set uri on NULL transaction");
+      return false;
+    }
+
+    if (NULL == uri) {
+      nrl_error(NRL_API, "uri cannot be NULL");
+      return false;
+    }
+
+    nr_txn_set_request_uri(transaction->txn, uri);
+    nrl_debug(NRL_API, "uri set to: \"%s\"", uri);
+    return true;
+}
+
+bool newrelic_set_request_referer(newrelic_txn_t* transaction,
+                                  const char* request_referer) {
+  if (NULL == transaction) {
+      nrl_error(NRL_API, "unable to set referer on NULL transaction");
+      return false;
+  }
+
+  if (NULL == request_referer) {
+    nrl_error(NRL_API, "request_referer cannot be NULL");
+    return false;
+  }
+
+  nr_txn_set_request_referer(transaction->txn, request_referer);
+  nrl_debug(NRL_API, "referer set to: \"%s\"", request_referer);
+  return true;
+}
+
+bool newrelic_set_request_content_length(newrelic_txn_t* transaction,
+                                         const char* content_length) {
+  if (NULL == transaction) {
+    nrl_error(NRL_API, "unable to set content length on NULL transaction");
+    return false;
+  }
+
+  if (NULL == content_length) {
+    nrl_error(NRL_API, "content_length cannot be NULL");
+    return false;
+  }
+
+  nr_txn_set_request_content_length(transaction->txn, content_length);
+  nrl_debug(NRL_API, "content_length set to: \"%s\"", content_length);
+  return true;
+}
+
+bool newrelic_set_http_status(newrelic_txn_t* transaction,
+                              int http_code) {
+
+  if (NULL == transaction) {
+    nrl_error(NRL_API, "unable to set http_code on NULL transactin");
+    return false;
+  }
+
+  if (0 == http_code) {
+    nrl_error(NRL_API, "status code cannot be 0");
+    return false;
+  }
+
+  nr_txn_set_http_status(transaction->txn, http_code);
+  nrl_debug(NRL_API, "http_code set to: \"%d\"", http_code);
+  return true;
+}

--- a/tests/test_txn.c
+++ b/tests/test_txn.c
@@ -147,7 +147,7 @@ static void test_txn_naming(void** state) {
 /*
  * Purpose: Tests we can set uri on a transaction
  */
-static void test_txn_uri(void **state) {
+static void test_txn_uri(void** state) {
   newrelic_app_t* appWithInfo = (newrelic_app_t*)*state;
   bool ret = false;
   newrelic_txn_t* txn = NULL;
@@ -183,7 +183,7 @@ static void test_txn_uri(void **state) {
 /*
  * Purpose: Tests we can set referer on a transaction
  */
-static void test_txn_referer(void **state) {
+static void test_txn_referer(void** state) {
   newrelic_app_t* appWithInfo = (newrelic_app_t*)*state;
   bool ret = false;
   newrelic_txn_t* txn = NULL;
@@ -219,7 +219,7 @@ static void test_txn_referer(void **state) {
 /*
  * Purpose: Tests we can set content length on a transaction
  */
-static void test_txn_content_length(void **state) {
+static void test_txn_content_length(void** state) {
   newrelic_app_t* appWithInfo = (newrelic_app_t*)*state;
   bool ret = false;
   newrelic_txn_t* txn = NULL;
@@ -255,7 +255,7 @@ static void test_txn_content_length(void **state) {
 /*
  * Purpose: Tests we can set http status on a transaction
  */
-static void test_txn_http_status(void **state) {
+static void test_txn_http_status(void** state) {
   newrelic_app_t* appWithInfo = (newrelic_app_t*)*state;
   bool ret = false;
   newrelic_txn_t* txn = NULL;

--- a/tests/test_txn.c
+++ b/tests/test_txn.c
@@ -143,6 +143,151 @@ static void test_txn_naming(void** state) {
 
   newrelic_end_transaction(&txn);
 }
+
+/*
+ * Purpose: Tests we can set uri on a transaction
+ */
+static void test_txn_uri(void **state) {
+  newrelic_app_t* appWithInfo = (newrelic_app_t*)*state;
+  bool ret = false;
+  newrelic_txn_t* txn = NULL;
+
+  /*
+   * Check that a NULL transaction cannot has uri
+   */
+  ret = newrelic_set_transaction_uri(txn, "aUri");
+  assert_false(ret);
+
+  /*
+   * Setup a valid transaction
+   */
+  txn = newrelic_start_transaction(appWithInfo, "aTransaction", false);
+  assert_non_null(txn);
+  assert_non_null(txn->txn);
+
+  /*
+   * Check transaction uri handles a NULL name
+   */
+  ret = newrelic_set_transaction_uri(txn, NULL);
+  assert_false(ret);
+
+  /*
+   * Check transaction uri success
+   */
+  ret = newrelic_set_transaction_name(txn, "New URI");
+  assert_true(ret);
+
+  newrelic_end_transaction(&txn);
+}
+
+/*
+ * Purpose: Tests we can set referer on a transaction
+ */
+static void test_txn_referer(void **state) {
+  newrelic_app_t* appWithInfo = (newrelic_app_t*)*state;
+  bool ret = false;
+  newrelic_txn_t* txn = NULL;
+
+  /*
+   * Check that a NULL transaction cannot has uri
+   */
+  ret = newrelic_set_request_referer(txn, "aReferer");
+  assert_false(ret);
+
+  /*
+   * Setup a valid transaction
+   */
+  txn = newrelic_start_transaction(appWithInfo, "aTransaction", false);
+  assert_non_null(txn);
+  assert_non_null(txn->txn);
+
+  /*
+   * Check transaction referer handles a NULL name
+   */
+  ret = newrelic_set_request_referer(txn, NULL);
+  assert_false(ret);
+
+  /*
+   * Check transaction referer success
+   */
+  ret = newrelic_set_request_referer(txn, "New Referer");
+  assert_true(ret);
+
+  newrelic_end_transaction(&txn);
+}
+
+/*
+ * Purpose: Tests we can set content length on a transaction
+ */
+static void test_txn_content_length(void **state) {
+  newrelic_app_t* appWithInfo = (newrelic_app_t*)*state;
+  bool ret = false;
+  newrelic_txn_t* txn = NULL;
+
+  /*
+   * Check that a NULL transaction cannot has content length
+   */
+  ret = newrelic_set_request_content_length(txn, "aContentLength");
+  assert_false(ret);
+
+  /*
+   * Setup a valid transaction
+   */
+  txn = newrelic_start_transaction(appWithInfo, "aTransaction", false);
+  assert_non_null(txn);
+  assert_non_null(txn->txn);
+
+  /*
+   * Check transaction content length handles a NULL name
+   */
+  ret = newrelic_set_request_content_length(txn, NULL);
+  assert_false(ret);
+
+  /*
+   * Check transaction content length success
+   */
+  ret = newrelic_set_request_content_length(txn, "aContentLength");
+  assert_true(ret);
+
+  newrelic_end_transaction(&txn);
+}
+
+/*
+ * Purpose: Tests we can set http status on a transaction
+ */
+static void test_txn_http_status(void **state) {
+  newrelic_app_t* appWithInfo = (newrelic_app_t*)*state;
+  bool ret = false;
+  newrelic_txn_t* txn = NULL;
+
+  /*
+   * Check that a NULL transaction cannot has http status
+   */
+  ret = newrelic_set_http_status(txn, 500);
+  assert_false(ret);
+
+  /*
+   * Setup a valid transaction
+   */
+  txn = newrelic_start_transaction(appWithInfo, "aTransaction", false);
+  assert_non_null(txn);
+  assert_non_null(txn->txn);
+
+  /*
+   * Check transaction http status handles a 0 code
+   */
+  ret = newrelic_set_http_status(txn, 0);
+  assert_false(ret);
+
+  /*
+   * Check transaction http status success
+   */
+  ret = newrelic_set_http_status(txn, 200);
+  assert_true(ret);
+
+  newrelic_end_transaction(&txn);
+}
+
 /*
  * Purpose: Main entry point (i.e. runs the tests)
  */
@@ -153,6 +298,10 @@ int main(void) {
       cmocka_unit_test(test_txn_valid),
       cmocka_unit_test(test_txn_ignore),
       cmocka_unit_test(test_txn_naming),
+      cmocka_unit_test(test_txn_uri),
+      cmocka_unit_test(test_txn_referer),
+      cmocka_unit_test(test_txn_content_length),
+      cmocka_unit_test(test_txn_http_status),
   };
 
   return cmocka_run_group_tests(license_tests,     /* our tests */


### PR DESCRIPTION
Enable the libnewrelic.a to have access to the following Agent Attributes instead of publishing them as Custom Attributes into NewRelic.

* Transaction URI
* Request Referrer
* Request Content Length
* Request HTTP Status

This idea comes from the development of a Lua Library on top o C-SDK which can publish Custom Attributes into New Relic using the proper methods, but it doesn't have access to any method to publish "those Agent Attributes" as Agent Attributes.