### PR TITLE
Removed accessing oldptr while realloc has failed.

### DIFF
--- a/vendor/newrelic/axiom/util_memory.c
+++ b/vendor/newrelic/axiom/util_memory.c
@@ -90,8 +90,7 @@ void* NRMALLOCSZ(2) nr_realloc(void* oldptr, size_t newsize) {
 
   ret = (realloc)(oldptr, newsize);
   if (nrunlikely(0 == ret)) {
-    nrl_error(NRL_MEMORY, "failed to reallocate %p for %zu bytes", oldptr,
-              newsize);
+    nrl_error(NRL_MEMORY, "failed to reallocate %zu bytes", newsize);
     exit(3);
   }
 


### PR DESCRIPTION
Newer versions of compilers fail on:
```
#12 7.662 In file included from util_memory.c:10:
#12 7.662 util_memory.c: In function ‘nr_realloc’:
#12 7.662 util_logging.h:218:7: error: pointer ‘oldptr’ may be used after ‘realloc’ [-Werror=use-after-free]
#12 7.662   218 |       nrl_send_log_message(NRL_ERROR, __VA_ARGS__); \
#12 7.662       |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#12 7.662 util_memory.c:93:5: note: in expansion of macro ‘nrl_error’
#12 7.662    93 |     nrl_error(NRL_MEMORY, "failed to reallocate %p for %zu bytes", oldptr,
#12 7.662       |     ^~~~~~~~~
#12 7.662 util_memory.c:91:9: note: call to ‘realloc’ here
#12 7.662    91 |   ret = (realloc)(oldptr, newsize);
#12 7.662       |         ^~~~~~~~~~~~~~~~~~~~~~~~~~
#12 7.669 cc1: all warnings being treated as errors
#12 7.671 make[1]: *** [Makefile:165: util_memory.o] Error 1
#12 7.672 make[1]: Leaving directory '/newrelic/vendor/newrelic/axiom'
#12 7.673 make: *** [Makefile:88: vendor/newrelic/axiom/libaxiom.a] Error 2
```
It's because as stated here: https://en.cppreference.com/w/c/memory/realloc - "The original pointer ptr is invalidated and any access to it is undefined behavior (even if reallocation was in-place).". 